### PR TITLE
Return spdgp simulation results as numeric vectors in base R

### DIFF
--- a/R/dgp.R
+++ b/R/dgp.R
@@ -307,7 +307,7 @@ sim_error <- function(u, listw, lambda = 0.5, model = c("sar", "ma")) {
   } else {
     stop("Error: unsupported model type")
   }
-  as.vector(y)
+  as.numeric(y)
 }
 
 
@@ -443,7 +443,7 @@ sim_slx_error <- function(u, xb, wxg, listw, lambda = 0.5, model = c("sar", "ma"
     "sar" = inverse_prod(listw, u, lambda),
     "ma" = u + lambda * spdep::lag.listw(listw, u)
   )
-  xb + wxg + u1
+  as.numeric(xb + wxg + u1)
 }
 
 #' Simulate Spatial Lag Model (SAR)
@@ -558,8 +558,7 @@ sim_sarar <- function(u, xb, listw, rho = 0.5, lambda = 0.2, model = c("sar", "m
   )
 
   y1 <- xb + u1
-  inverse_prod(listw, y1, rho)
-
+  as.numeric(inverse_prod(listw, y1, rho))
 }
 
 
@@ -589,7 +588,7 @@ sim_gns <- function(u, xb, wxg, listw, rho = 0.5, lambda = 0.2, model = c("sar",
   )
 
   y1 <- xb + wxg + u1 
-  inverse_prod(listw, y1, rho)
+  as.numeric(inverse_prod(listw, y1, rho))
 }
 
 #' Simiulate Matrix Exponential Spatial Lag Model


### PR DESCRIPTION
The current `sim_*` functions return results inconsistently. In this PR, I standardize the output by using `as.numeric()` to convert the results to numeric vectors in base R.